### PR TITLE
#9 - Backend: criar entidade Participante

### DIFF
--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ParticipantesController.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ParticipantesController.java
@@ -1,0 +1,47 @@
+package pe.rec.comunidades.manguebits.controllers;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pe.rec.comunidades.manguebits.utils.ErrorResponse;
+import pe.rec.comunidades.manguebits.dto.ParticipantesDTO;
+import pe.rec.comunidades.manguebits.interfaces.services.IParticipantesService;
+import pe.rec.comunidades.manguebits.model.Participantes;
+
+@RestController
+@RequestMapping("/manguebits/participantes")
+public class ParticipantesController {
+
+    private final IParticipantesService participantesService;
+
+    public ParticipantesController(IParticipantesService participanteService) {
+        this.participantesService = participanteService;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> criarParticipante(@RequestBody ParticipantesDTO dto) {
+        try {
+            Participantes participante = new Participantes();
+            participante.setNome(dto.getNome());
+            participante.setCpf(dto.getCpf());
+            participante.setEmail(dto.getEmail());
+            participante.setSenha(dto.getSenha());
+
+            Participantes criado = participantesService.createParticipante(participante);
+
+            // Retorna a entidade criada diretamente
+            return ResponseEntity.ok(criado);
+
+        } catch (IllegalArgumentException ex) {
+            // Retorna a mensagem de erro personalizada
+            return ResponseEntity
+                    .status(400)
+                    .body(new ErrorResponse(ex.getMessage()));
+        }
+    }
+}
+

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/ParticipantesDTO.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/ParticipantesDTO.java
@@ -1,0 +1,20 @@
+package pe.rec.comunidades.manguebits.dto;
+
+public class ParticipantesDTO {
+    private String nome;
+    private String cpf;
+    private String email;
+    private String senha;
+
+    public String getNome() { return nome; }
+    public void setNome(String nome) { this.nome = nome; }
+
+    public String getCpf() { return cpf; }
+    public void setCpf(String cpf) { this.cpf = cpf; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getSenha() { return senha; }
+    public void setSenha(String senha) { this.senha = senha; }
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/interfaces/services/IParticipantesService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/interfaces/services/IParticipantesService.java
@@ -1,0 +1,7 @@
+package pe.rec.comunidades.manguebits.interfaces.services;
+
+import pe.rec.comunidades.manguebits.model.Participantes;
+
+public interface IParticipantesService {
+    Participantes createParticipante(Participantes participante);
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Participantes.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Participantes.java
@@ -1,0 +1,113 @@
+package pe.rec.comunidades.manguebits.model;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "participantes")
+public class Participantes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_participante")
+    private Long id;
+
+    @Column(name = "nome", nullable = false, length = 150)
+    private String nome;
+
+    @Column(name = "cpf", length = 11, unique = true)
+    private String cpf;
+
+    @Column(name = "email", nullable = false, unique = true, length = 150)
+    private String email;
+
+    @Column(name = "senha", nullable = false, length = 255)
+    private String senha;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(String cpf) {
+        this.cpf = cpf;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getSenha() {
+        return senha;
+    }
+
+    public void setSenha(String senha) {
+        this.senha = senha;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Participantes that = (Participantes) o;
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31;
+    }
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/repositories/ParticipantesRepository.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/repositories/ParticipantesRepository.java
@@ -1,0 +1,11 @@
+package pe.rec.comunidades.manguebits.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import pe.rec.comunidades.manguebits.model.Participantes;
+
+import java.util.Optional;
+
+public interface ParticipantesRepository extends JpaRepository<Participantes, Long> {
+    Optional<Participantes> findByEmail(String email);
+    Optional<Participantes> findByCpf(String cpf);
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ParticipantesService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ParticipantesService.java
@@ -1,0 +1,37 @@
+package pe.rec.comunidades.manguebits.services;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import pe.rec.comunidades.manguebits.repositories.ParticipantesRepository;
+import pe.rec.comunidades.manguebits.interfaces.services.IParticipantesService;
+import pe.rec.comunidades.manguebits.model.Participantes;
+
+import java.util.Optional;
+
+@Service
+public class ParticipantesService implements IParticipantesService {
+
+    private final ParticipantesRepository participantesRepository;
+
+    public ParticipantesService(ParticipantesRepository participantesRepository) {
+        this.participantesRepository = participantesRepository;
+    }
+
+    @Override
+    public Participantes createParticipante(Participantes participante) {
+        Optional<Participantes> existenteEmail = participantesRepository.findByEmail(participante.getEmail());
+        if (existenteEmail.isPresent()) {
+            throw new IllegalArgumentException("Já existe um participante com esse email!");
+        }
+
+        if (participante.getCpf() != null && !participante.getCpf().isEmpty()) {
+            Optional<Participantes> existenteCpf = participantesRepository.findByCpf(participante.getCpf());
+            if (existenteCpf.isPresent()) {
+                throw new IllegalArgumentException("Já existe um participante com esse CPF!");
+            }
+        }
+
+        return participantesRepository.save(participante);
+    }
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/ErrorResponse.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/ErrorResponse.java
@@ -1,0 +1,17 @@
+package pe.rec.comunidades.manguebits.utils;
+
+public class ErrorResponse {
+    private String mensagem;
+
+    public ErrorResponse(String mensagem) {
+        this.mensagem = mensagem;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public void setMensagem(String mensagem) {
+        this.mensagem = mensagem;
+    }
+}


### PR DESCRIPTION
## Descrição

- Implementa criação de participantes com validação de email e CPF únicos.
- Criação de ParticipantesDTO, ParticipantesService e ParticipantesController.
- Persiste dados no banco via ParticipantesRepository.
- Retorna mensagens personalizadas de erro em caso de duplicidade.

## Issue relacionada:

#9 