### PR TITLE
Task #29 -  Implementado relacionamento entre Posts e Comunidades, método e CRUD

### DIFF
--- a/manguebits/pom.xml
+++ b/manguebits/pom.xml
@@ -40,6 +40,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc11</artifactId>
+			<version>21.9.0.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ComunidadesController.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ComunidadesController.java
@@ -10,6 +10,7 @@ import pe.rec.comunidades.manguebits.dto.comunidadesDTO.ComunidadesUpdateDTO;
 import pe.rec.comunidades.manguebits.model.Comunidades;
 import pe.rec.comunidades.manguebits.services.ComunidadesService;
 import pe.rec.comunidades.manguebits.utils.ErrorResponse;
+import pe.rec.comunidades.manguebits.utils.communitiesUtils.ComunidadesUtils;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,12 +22,10 @@ public class ComunidadesController {
     private final ComunidadesService service;
 
     @Autowired
-    public ComunidadesController(ComunidadesService service) {
-        this.service = service;
-    }
+    public ComunidadesController(ComunidadesService service) { this.service = service; }
 
-    @PostMapping(value = "/v1")
-    public ResponseEntity<?> create(@RequestBody @Valid ComunidadesCreateDTO communityDTO) {
+    @PostMapping(value = {"/v1/"})
+    public ResponseEntity<?> create(/*@Valid*/@RequestBody ComunidadesCreateDTO communityDTO) {
         try {
             return ResponseEntity.status(HttpStatus.CREATED).body(
                     this.service.save(communityDTO));
@@ -47,10 +46,10 @@ public class ComunidadesController {
         }
     }
 
-    @GetMapping(value = {"/v1/"})
+    @GetMapping(value = {"/v1"})
     public ResponseEntity<List<Comunidades>> findAll() {
         List<Comunidades> communities = this.service.findAll().stream()
-                .map(community -> new Comunidades())
+                .map(ComunidadesUtils::mapToComunidades)
                 .collect(Collectors.toList());
         return ResponseEntity.status(HttpStatus.OK).body(communities);
     }
@@ -58,7 +57,7 @@ public class ComunidadesController {
     @PutMapping(value = {"/v1/{id}"})
     public ResponseEntity<?> update(
             @PathVariable(value = "id") Long id,
-            @RequestBody @Valid ComunidadesUpdateDTO communityUpdateDTO) {
+            @RequestBody /*@Valid*/ ComunidadesUpdateDTO communityUpdateDTO) {
         try {
             return ResponseEntity.status(HttpStatus.ACCEPTED).body(
                     this.service.update(id, communityUpdateDTO)

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ComunidadesController.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ComunidadesController.java
@@ -1,12 +1,12 @@
 package pe.rec.comunidades.manguebits.controllers;
 
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pe.rec.comunidades.manguebits.dto.comunidadesDTO.ComunidadesCreateDTO;
 import pe.rec.comunidades.manguebits.dto.comunidadesDTO.ComunidadesUpdateDTO;
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsCreateDTO;
 import pe.rec.comunidades.manguebits.model.Comunidades;
 import pe.rec.comunidades.manguebits.services.ComunidadesService;
 import pe.rec.comunidades.manguebits.utils.ErrorResponse;
@@ -28,7 +28,20 @@ public class ComunidadesController {
     public ResponseEntity<?> create(/*@Valid*/@RequestBody ComunidadesCreateDTO communityDTO) {
         try {
             return ResponseEntity.status(HttpStatus.CREATED).body(
-                    this.service.save(communityDTO));
+                    this.service.save(communityDTO).value());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    new ErrorResponse(e.getMessage()));
+        }
+    }
+
+    @PostMapping(value = {"/v1/create-posts/{id}"})
+    public ResponseEntity<?> createPostsInComuniddes(
+            @PathVariable(value = "id") Long id,
+            @RequestBody PostsCreateDTO postsCreateDTO) {
+        try {
+            return ResponseEntity.status(HttpStatus.CREATED).body(
+                    this.service.savePostsInComunidades(postsCreateDTO, id));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
                     new ErrorResponse(e.getMessage()));
@@ -46,10 +59,29 @@ public class ComunidadesController {
         }
     }
 
+    @GetMapping(value = {"/v1/fetchPosts/{id}"})
+    public ResponseEntity<?> findByIdFetchPosts(@PathVariable(value = "id") Long id) {
+        try {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    this.service.findByIdFetchPosts(id));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    new ErrorResponse(e.getMessage()));
+        }
+    }
+
     @GetMapping(value = {"/v1"})
     public ResponseEntity<List<Comunidades>> findAll() {
         List<Comunidades> communities = this.service.findAll().stream()
                 .map(ComunidadesUtils::mapToComunidades)
+                .collect(Collectors.toList());
+        return ResponseEntity.status(HttpStatus.OK).body(communities);
+    }
+
+    @GetMapping(value = {"/v1/fetchPosts"})
+    public ResponseEntity<List<Comunidades>> findAllFetchPosts() {
+        List<Comunidades> communities = this.service.findAllFetchPosts().stream()
+                .map(ComunidadesUtils::mapToComunidadesFetchPosts)
                 .collect(Collectors.toList());
         return ResponseEntity.status(HttpStatus.OK).body(communities);
     }
@@ -60,7 +92,7 @@ public class ComunidadesController {
             @RequestBody /*@Valid*/ ComunidadesUpdateDTO communityUpdateDTO) {
         try {
             return ResponseEntity.status(HttpStatus.ACCEPTED).body(
-                    this.service.update(id, communityUpdateDTO)
+                    this.service.update(id, communityUpdateDTO).value()
             );
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/PostController.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/PostController.java
@@ -1,9 +1,11 @@
 package pe.rec.comunidades.manguebits.controllers;
 
-import pe.rec.comunidades.manguebits.dto.postsDTO.PostsDTO;
+import org.springframework.http.HttpStatus;
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsUpdateDTO;
 import pe.rec.comunidades.manguebits.interfaces.services.IPostService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import pe.rec.comunidades.manguebits.utils.ErrorResponse;
 
 import java.util.List;
 
@@ -17,36 +19,42 @@ public class PostController {
         this.postService = postService;
     }
 
-    @PostMapping
-    public ResponseEntity<PostsDTO> criarPost(@RequestBody PostsDTO postsDTO) {
-        PostsDTO criado = postService.createPost(postsDTO);
-        return ResponseEntity.status(201).body(criado);
+    @GetMapping(value = {"/v1/{id}"})
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        try {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    this.postService.findById(id));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    new ErrorResponse(e.getMessage()));
+        }
     }
 
-    @GetMapping
-    public ResponseEntity<List<PostsDTO>> listarPosts() {
-        List<PostsDTO> lista = postService.getAllPosts();
-        return ResponseEntity.ok(lista);
-    }
-
-    @GetMapping("/{id}")
-    public ResponseEntity<PostsDTO> buscarPostPorId(@PathVariable Long id) {
-        PostsDTO post = postService.getPostById(id);
-        return ResponseEntity.ok(post);
-    }
-
-    @PutMapping("/{id}")
-    public ResponseEntity<PostsDTO> atualizarPost(
+    @PutMapping(value = {"/v1/{id}"})
+    public ResponseEntity<?> updatePost(
             @PathVariable Long id,
-            @RequestBody PostsDTO postsDTO
+            @RequestBody PostsUpdateDTO postsUpdateDTO
     ) {
-        PostsDTO atualizado = postService.updatePost(id, postsDTO);
-        return ResponseEntity.ok(atualizado);
+        try {
+            return ResponseEntity.status(HttpStatus.ACCEPTED).body(
+                    this.postService.updatePost(id, postsUpdateDTO).value()
+            );
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    new ErrorResponse(e.getMessage())
+            );
+        }
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletarPost(@PathVariable Long id) {
-        postService.deletePost(id);
-        return ResponseEntity.noContent().build();
+    @DeleteMapping(value = {"/v1/{id}"})
+    public ResponseEntity<?> delete(@PathVariable(value = "id") Long id) {
+        try {
+            this.postService.deletePost(id);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    new ErrorResponse(e.getMessage())
+            );
+        }
     }
 }

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/comunidadesDTO/ComunidadesCreateDTO.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/comunidadesDTO/ComunidadesCreateDTO.java
@@ -1,27 +1,22 @@
 package pe.rec.comunidades.manguebits.dto.comunidadesDTO;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import pe.rec.comunidades.manguebits.enums.Categoria;
 import pe.rec.comunidades.manguebits.model.Comunidades;
 
-import java.time.LocalDateTime;
 
 public record ComunidadesCreateDTO(
-        @NotBlank(message = "Atributo <nome> é obrigatório!") @NotEmpty String nome,
+        @NotBlank(message = "Atributo <conteudo> é obrigatório!") String nome,
         @NotBlank(message = "Atributo <descricao> é obrigatório!") String descricao,
         @NotBlank(message = "Atributo <administrador> é obrigatório!") String administrador,
         @NotBlank(message = "Atributo <categoria> é obrigatório!") Categoria categoria
 ) {
     public static Comunidades toEntity(ComunidadesCreateDTO requestDTO) {
-        return new Comunidades(
-                null,
-                requestDTO.nome(),
-                requestDTO.descricao(),
-                requestDTO.administrador(),
-                requestDTO.categoria(),
-                LocalDateTime.now(),
-                LocalDateTime.now()
-        );
+        Comunidades community = new Comunidades();
+        community.setNome(requestDTO.nome());
+        community.setDescricao(requestDTO.descricao());
+        community.setAdministrador(requestDTO.administrador());
+        community.setCategoria(requestDTO.categoria());
+        return community;
     }
 }

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/comunidadesDTO/ComunidadesUpdateDTO.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/comunidadesDTO/ComunidadesUpdateDTO.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import pe.rec.comunidades.manguebits.enums.Categoria;
 
 public record ComunidadesUpdateDTO(
-        @NotBlank(message = "Atributo <nome> é obrigatório!") String nome,
+        @NotBlank(message = "Atributo <conteudo> é obrigatório!") String nome,
         @NotBlank(message = "Atributo <descricao> é obrigatório!") String descricao,
         @NotBlank(message = "Atributo <categoria> é obrigatório!") Categoria categoria
 ) {}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsCreateDTO.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsCreateDTO.java
@@ -1,11 +1,16 @@
 package pe.rec.comunidades.manguebits.dto.postsDTO;
 
-import java.time.LocalDateTime;
+import pe.rec.comunidades.manguebits.model.Comunidades;
+import pe.rec.comunidades.manguebits.model.Posts;
 
-public record PostsDTO(
-        String conteudo,
-        Integer curtidas,
-        Integer idComunidade,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
-) {}
+public record PostsCreateDTO(
+        String conteudo
+) {
+    public static Posts toEntity(PostsCreateDTO postsCreateDTO, Comunidades community) {
+        Posts post = new Posts();
+        post.setConteudo(postsCreateDTO.conteudo());
+        post.setCurtidas(0);
+        post.setComunidade(community);
+        return post;
+    }
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsCreateDTO.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsCreateDTO.java
@@ -3,8 +3,7 @@ package pe.rec.comunidades.manguebits.dto.postsDTO;
 import java.time.LocalDateTime;
 
 public record PostsDTO(
-        Long idPost,
-        String nome,
+        String conteudo,
         Integer curtidas,
         Integer idComunidade,
         LocalDateTime createdAt,

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsResponseDTO.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsResponseDTO.java
@@ -1,0 +1,25 @@
+package pe.rec.comunidades.manguebits.dto.postsDTO;
+
+import pe.rec.comunidades.manguebits.model.Posts;
+
+import java.time.LocalDateTime;
+
+public record PostsResponseDTO(
+        Long idPost,
+        String conteudo,
+        Integer curtidas,
+        Long idComunidade,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PostsResponseDTO fromEntity(Posts post) {
+        return new PostsResponseDTO(
+                post.getIdPost(),
+                post.getConteudo(),
+                post.getCurtidas(),
+                post.getComunidade() != null ? post.getComunidade().getId() : null,
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsUpdateDTO.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/dto/postsDTO/PostsUpdateDTO.java
@@ -1,0 +1,7 @@
+package pe.rec.comunidades.manguebits.dto.postsDTO;
+
+
+public record PostsUpdateDTO(
+        String conteudo,
+        Integer curtidas
+) {}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/interfaces/services/IPostService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/interfaces/services/IPostService.java
@@ -1,12 +1,14 @@
 package pe.rec.comunidades.manguebits.interfaces.services;
 
-import pe.rec.comunidades.manguebits.dto.postsDTO.PostsDTO;
-import java.util.List;
+import org.springframework.http.HttpStatus;
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsCreateDTO;
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsUpdateDTO;
+import pe.rec.comunidades.manguebits.model.Comunidades;
+import pe.rec.comunidades.manguebits.model.Posts;
 
 public interface IPostService {
-    PostsDTO createPost(PostsDTO postDTO);
-    PostsDTO getPostById(Long id);
-    List<PostsDTO> getAllPosts();
-    PostsDTO updatePost(Long id, PostsDTO postsDTO);
+    void createPost(PostsCreateDTO postDTO, Comunidades community);
+    Posts findById(Long id);
+    HttpStatus updatePost(Long id, PostsUpdateDTO postsUpdateDTO);
     void deletePost(Long id);
 }

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
@@ -20,7 +20,7 @@ public class Comunidades implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id_comunidade")
     private Long id;
-    @Column(name = "conteudo", nullable = false, length = 150)
+    @Column(name = "nome", nullable = false, length = 150)
     private String nome;
     @Column(name = "descricao", nullable = false, length = 550)
     private String descricao;
@@ -33,7 +33,7 @@ public class Comunidades implements Serializable {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
     @OneToMany(mappedBy = "comunidade", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private final List<Posts> posts = new ArrayList<Posts>();
+    private List<Posts> posts = new ArrayList<Posts>();
 
 
     public Comunidades() {}
@@ -47,26 +47,30 @@ public class Comunidades implements Serializable {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
+    public Comunidades(Long id, String nome, String descricao, String administrador,
+                       Categoria categoria, LocalDateTime createdAt, LocalDateTime updatedAt, List<Posts> posts) {
+        this.id = id;
+        this.nome = nome;
+        this.descricao = descricao;
+        this.administrador = administrador;
+        this.categoria = categoria;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.posts = posts;
+    }
 
 
     public Long getId() {return id;}
-
     public String getNome() {return nome;}
     public void setNome(String nome) {this.nome = nome;}
-
     public String getDescricao() {return descricao;}
     public void setDescricao(String descricao) {this.descricao = descricao;}
-
     public String getAdministrador() {return administrador;}
     public void setAdministrador(String administrador) {this.administrador = administrador;}
-
     public Categoria getCategoria() {return categoria;}
     public void setCategoria(Categoria categoria) {this.categoria = categoria;}
-
     public LocalDateTime getCreatedAt() {return createdAt;}
-
     public LocalDateTime getUpdatedAt() {return updatedAt;}
-
     public List<Posts> getPosts() { return posts; }
 
     public void addPost(Posts post) {

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
@@ -6,6 +6,8 @@ import pe.rec.comunidades.manguebits.enums.Categoria;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 
@@ -18,7 +20,7 @@ public class Comunidades implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id_comunidade")
     private Long id;
-    @Column(name = "nome", nullable = false, length = 150)
+    @Column(name = "conteudo", nullable = false, length = 150)
     private String nome;
     @Column(name = "descricao", nullable = false, length = 550)
     private String descricao;
@@ -30,6 +32,8 @@ public class Comunidades implements Serializable {
     private LocalDateTime createdAt;
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+    @OneToMany(mappedBy = "comunidade", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private final List<Posts> posts = new ArrayList<Posts>();
 
 
     public Comunidades() {}
@@ -46,7 +50,6 @@ public class Comunidades implements Serializable {
 
 
     public Long getId() {return id;}
-    public void setId(Long id) {this.id = id;}
 
     public String getNome() {return nome;}
     public void setNome(String nome) {this.nome = nome;}
@@ -61,11 +64,19 @@ public class Comunidades implements Serializable {
     public void setCategoria(Categoria categoria) {this.categoria = categoria;}
 
     public LocalDateTime getCreatedAt() {return createdAt;}
-    public void setCreatedAt(LocalDateTime createdAt) {this.createdAt = createdAt;}
 
     public LocalDateTime getUpdatedAt() {return updatedAt;}
-    public void setUpdatedAt(LocalDateTime updatedAt) {this.updatedAt = updatedAt;}
 
+    public List<Posts> getPosts() { return posts; }
+
+    public void addPost(Posts post) {
+        this.posts.add(post);
+        post.setComunidade(this);
+    }
+    public void removePost(Posts post) {
+        this.posts.remove(post);
+        post.setComunidade(null);
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Posts.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Posts.java
@@ -1,5 +1,6 @@
 package pe.rec.comunidades.manguebits.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
@@ -7,34 +8,41 @@ import java.time.LocalDateTime;
 @Table(name = "posts")
 public class Posts {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long idPost;
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long idPost;
+    @Column(name = "conteudo", nullable = false, length = 380) private String conteudo;
+    @Column(name = "curtidas", nullable = false) private Integer curtidas;
+    @Column(name = "created_at", nullable = false, updatable = false) private LocalDateTime createdAt;
+    @Column(name = "updated_at", nullable = false) private LocalDateTime updatedAt;
+    @JsonIgnore @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "id_comunidade", nullable = false) private Comunidades comunidade;
 
-    private String nome;
-    private Integer curtidas = 0;
 
-    @Column(nullable = false)
-    private Integer idComunidade;
+    public Posts() {}
+    public Posts(Long idPost, String conteudo, Integer curtidas, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.idPost = idPost;
+        this.conteudo = conteudo;
+        this.curtidas = curtidas;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
+    public Long getIdPost() { return idPost; }
+    public String getConteudo() { return this.conteudo; }
+    public void setConteudo(String conteudo) { this.conteudo = conteudo; }
+    public Integer getCurtidas() { return curtidas; }
+    public void setCurtidas(Integer curtidas) { this.curtidas = curtidas; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public Comunidades getComunidade() { return comunidade; }
+    public void setComunidade(Comunidades comunidade) { this.comunidade = comunidade; }
 
-    private LocalDateTime updatedAt = LocalDateTime.now();
 
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
     @PreUpdate
     public void preUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
-
-    public Long getIdPost() { return idPost; }
-    public void setIdPost(Long idPost) { this.idPost = idPost; }
-    public String getNome() { return this.nome; }
-    public void setNome(String nome) { this.nome = nome; }
-    public Integer getCurtidas() { return curtidas; }
-    public void setCurtidas(Integer curtidas) { this.curtidas = curtidas; }
-    public Integer getIdComunidade() { return idComunidade; }
-    public void setIdComunidade(Integer idComunidade) { this.idComunidade = idComunidade; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
 }

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/repositories/ComunidadesRepository.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/repositories/ComunidadesRepository.java
@@ -1,8 +1,20 @@
 package pe.rec.comunidades.manguebits.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import pe.rec.comunidades.manguebits.model.Comunidades;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public interface ComunidadesRepository extends JpaRepository<Comunidades, Long> {}
+public interface ComunidadesRepository extends JpaRepository<Comunidades, Long> {
+
+    @Query("SELECT C FROM Comunidades C LEFT JOIN FETCH C.posts WHERE C.ID = :id")
+    Optional<Comunidades> findByIdFetchPosts(@Param("id") Long id);
+
+    @Query("SELECT DISTINCT C FROM Comunidades C LEFT JOIN FETCH C.posts")
+    List<Comunidades> findAllFetchPosts();
+}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ComunidadesService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ComunidadesService.java
@@ -18,7 +18,7 @@ public class ComunidadesService {
     private final ComunidadesRepository repository;
 
     @Autowired
-    public ComunidadesService(ComunidadesRepository repository) {this.repository = repository;}
+    public ComunidadesService(ComunidadesRepository repository) { this.repository = repository; }
 
 
     public Comunidades save(ComunidadesCreateDTO communityDTO) {
@@ -29,7 +29,7 @@ public class ComunidadesService {
     public List<Comunidades> findAll() {return this.repository.findAll();}
 
     public Comunidades findById(Long id) {
-        Optional<Comunidades> community = this.repository.findById(id);
+        Optional<Comunidades> community = this.repository.findById(id).map(ComunidadesUtils::mapToComunidades);
         return community.orElseThrow(() -> new NoSuchElementException("Registro não encontrado!"));
     }
 

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ComunidadesService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ComunidadesService.java
@@ -2,9 +2,11 @@ package pe.rec.comunidades.manguebits.services;
 
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import pe.rec.comunidades.manguebits.dto.comunidadesDTO.ComunidadesCreateDTO;
 import pe.rec.comunidades.manguebits.dto.comunidadesDTO.ComunidadesUpdateDTO;
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsCreateDTO;
 import pe.rec.comunidades.manguebits.model.Comunidades;
 import pe.rec.comunidades.manguebits.repositories.ComunidadesRepository;
 import pe.rec.comunidades.manguebits.utils.communitiesUtils.ComunidadesUtils;
@@ -16,33 +18,56 @@ import java.util.Optional;
 @Service
 public class ComunidadesService {
     private final ComunidadesRepository repository;
+    private final PostsService postsService;
 
     @Autowired
-    public ComunidadesService(ComunidadesRepository repository) { this.repository = repository; }
+    public ComunidadesService(ComunidadesRepository repository, PostsService postsService) {
+        this.repository = repository;
+        this.postsService = postsService;
+    }
 
 
-    public Comunidades save(ComunidadesCreateDTO communityDTO) {
+    public HttpStatus save(ComunidadesCreateDTO communityDTO) {
+        HttpStatus saved = HttpStatus.CREATED;
         Comunidades community = ComunidadesCreateDTO.toEntity(communityDTO);
-        return this.repository.save(community);
+        try {
+            this.repository.save(community);
+        } catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        }
+        return saved;
+    }
+
+    public Comunidades savePostsInComunidades(PostsCreateDTO postsCreateDTO, Long idCommunity) {
+        Comunidades community = this.findById(idCommunity);
+        postsService.createPost(postsCreateDTO, community);
+        return this.findByIdFetchPosts(idCommunity);
     }
 
     public List<Comunidades> findAll() {return this.repository.findAll();}
+
+    public List<Comunidades> findAllFetchPosts() {return this.repository.findAllFetchPosts();}
 
     public Comunidades findById(Long id) {
         Optional<Comunidades> community = this.repository.findById(id).map(ComunidadesUtils::mapToComunidades);
         return community.orElseThrow(() -> new NoSuchElementException("Registro não encontrado!"));
     }
 
-    public boolean update(Long id, ComunidadesUpdateDTO communityUpdateDTO) {
-        boolean bool = false;
+    public Comunidades findByIdFetchPosts(Long id) {
+        return repository.findByIdFetchPosts(id)
+                .orElseThrow(() -> new RuntimeException("Comunidade não encontrada"));
+    }
+
+    public HttpStatus update(Long id, ComunidadesUpdateDTO communityUpdateDTO) {
+        HttpStatus updated = HttpStatus.NO_CONTENT;
         Comunidades community = this.findById(id);
         if (ComunidadesUtils.checksDataUpdate(community, communityUpdateDTO)){
             community.setNome(communityUpdateDTO.nome());
             community.setDescricao(communityUpdateDTO.descricao());
             this.repository.save(community);
-            bool = true;
+            updated = HttpStatus.ACCEPTED;
         }
-        return bool;
+        return updated;
     }
 
     public void delete(Long id) {

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/PostsService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/PostsService.java
@@ -1,69 +1,54 @@
 package pe.rec.comunidades.manguebits.services;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import pe.rec.comunidades.manguebits.dto.postsDTO.PostsDTO;
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsCreateDTO;
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsUpdateDTO;
 import pe.rec.comunidades.manguebits.interfaces.services.IPostService;
+import pe.rec.comunidades.manguebits.model.Comunidades;
 import pe.rec.comunidades.manguebits.model.Posts;
 import pe.rec.comunidades.manguebits.repositories.PostsRepository;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import pe.rec.comunidades.manguebits.utils.postsUtils.PostsUtils;
 
 @Service
 public class PostsService implements IPostService {
+    private final PostsRepository postsRepository;
 
-    private final PostsRepository repository;
-
-    public PostsService(PostsRepository repository) {
-        this.repository = repository;
+    @Autowired
+    public PostsService(PostsRepository postsRepository) {
+        this.postsRepository = postsRepository;
     }
 
     @Override
-    public PostsDTO createPost(PostsDTO postDTO) {
-        Posts post = new Posts();
-        post.setNome(postDTO.nome());
-        post.setIdComunidade(postDTO.idComunidade());
-        Posts saved = repository.save(post);
-        return mapToDTO(saved);
+    public void createPost(PostsCreateDTO postDTO, Comunidades community) {
+        Posts post = PostsCreateDTO.toEntity(postDTO, community);
+        postsRepository.save(post);
     }
 
     @Override
-    public PostsDTO getPostById(Long id) {
-        Optional<Posts> post = repository.findById(id);
-        return mapToDTO(post.get());
+    public Posts findById(Long id) {
+        return this.postsRepository.findById(id).orElseThrow(
+                () -> new RuntimeException("Nenhum Posts encontrado!"));
     }
 
     @Override
-    public List<PostsDTO> getAllPosts() {
-        return repository.findAll().stream()
-                .map(this::mapToDTO)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public PostsDTO updatePost(Long id, PostsDTO postDTO) {
-        Optional<Posts> post = repository.findById(id);
-        post.get().setNome(postDTO.nome());
-        post.get().setCurtidas(postDTO.curtidas());
-        post.get().setIdComunidade(postDTO.idComunidade());
-        Posts updated = repository.save(post.get());
-        return mapToDTO(updated);
+    public HttpStatus updatePost(Long id, PostsUpdateDTO postsUpdateDTO) {
+        HttpStatus updated = HttpStatus.NO_CONTENT;
+        Posts post = this.findById(id);
+        if (PostsUtils.checksDataUpdate(post, postsUpdateDTO)) {
+            post.setConteudo(postsUpdateDTO.conteudo());
+            post.setCurtidas(postsUpdateDTO.curtidas());
+            this.postsRepository.save(post);
+            updated = HttpStatus.ACCEPTED;
+        }
+        return updated;
     }
 
     @Override
     public void deletePost(Long id) {
-        Optional<Posts> post = this.repository.findById(id);
-        repository.delete(post.get());
+        Posts post = this.findById(id);
+        postsRepository.delete(post);
     }
 
-    private PostsDTO mapToDTO(Posts post) {
-        return new PostsDTO(
-                post.getIdPost(),
-                post.getNome(),
-                post.getCurtidas(),
-                post.getIdComunidade(),
-                post.getCreatedAt(),
-                post.getUpdatedAt()
-        );
-    }
 }

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/communitiesUtils/ComunidadesUtils.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/communitiesUtils/ComunidadesUtils.java
@@ -17,6 +17,12 @@ public class ComunidadesUtils {
                 community.getDescricao(), community.getAdministrador(),
                 community.getCategoria(), community.getCreatedAt(), community.getUpdatedAt());
     }
+
+    public static Comunidades mapToComunidadesFetchPosts(Comunidades community) {
+        return new Comunidades(community.getId(), community.getNome(),
+                community.getDescricao(), community.getAdministrador(),
+                community.getCategoria(), community.getCreatedAt(), community.getUpdatedAt(), community.getPosts());
+    }
 }
 
 

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/communitiesUtils/ComunidadesUtils.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/communitiesUtils/ComunidadesUtils.java
@@ -11,6 +11,12 @@ public class ComunidadesUtils {
         return !Objects.equals(community.getNome(), communityUpdateDTO.nome())
                 || !Objects.equals(community.getDescricao(), communityUpdateDTO.descricao());
     }
+
+    public static Comunidades mapToComunidades(Comunidades community) {
+        return new Comunidades(community.getId(), community.getNome(),
+                community.getDescricao(), community.getAdministrador(),
+                community.getCategoria(), community.getCreatedAt(), community.getUpdatedAt());
+    }
 }
 
 

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/postsUtils/PostsUtils.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/utils/postsUtils/PostsUtils.java
@@ -1,0 +1,14 @@
+package pe.rec.comunidades.manguebits.utils.postsUtils;
+
+import pe.rec.comunidades.manguebits.dto.postsDTO.PostsUpdateDTO;
+import pe.rec.comunidades.manguebits.model.Posts;
+
+import java.util.Objects;
+
+public class PostsUtils {
+
+    public static boolean checksDataUpdate(Posts posts, PostsUpdateDTO postsUpdateDTO) {
+        return !Objects.equals(posts.getConteudo(), postsUpdateDTO.conteudo())
+                || !Objects.equals(posts.getCurtidas(), postsUpdateDTO.curtidas());
+    }
+}


### PR DESCRIPTION
## Descrição Resumida
Este PR corresponde a Task #29 em que estabelece o relacionamento  entre `Posts `e `Comunidades `com as seguintes feats:
1. Implementado relacionamento (OneToMany e ManyToOne) entre `Posts `e `Comunidades`;
2. Implementado método para criar novos Posts a partir de Comunidades;
3. CRUD em Posts.