### PR TITLE
Criando relacionamento entre as entidades participantes e comunidades

### DIFF
--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ComunidadesController.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ComunidadesController.java
@@ -22,7 +22,9 @@ public class ComunidadesController {
     private final ComunidadesService service;
 
     @Autowired
-    public ComunidadesController(ComunidadesService service) { this.service = service; }
+    public ComunidadesController(ComunidadesService service) {
+        this.service = service;
+    }
 
     @PostMapping(value = {"/v1/"})
     public ResponseEntity<?> create(/*@Valid*/@RequestBody ComunidadesCreateDTO communityDTO) {
@@ -110,6 +112,30 @@ public class ComunidadesController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
                     new ErrorResponse(e.getMessage())
             );
+        }
+    }
+
+    @PostMapping(value = {"/v1/{idComunidade}/participantes/{idParticipante}"})
+    public ResponseEntity<?> adicionarParticipante(
+            @PathVariable Long idComunidade,
+            @PathVariable Long idParticipante) {
+        try {
+            HttpStatus status = service.adicionarParticipante(idComunidade, idParticipante);
+            return ResponseEntity.status(status).body("Participante adicionado com sucesso à comunidade.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
+        }
+    }
+
+    @DeleteMapping(value = {"/v1/{idComunidade}/participantes/{idParticipante}"})
+    public ResponseEntity<?> removerParticipante(
+            @PathVariable Long idComunidade,
+            @PathVariable Long idParticipante) {
+        try {
+            HttpStatus status = service.removerParticipante(idComunidade, idParticipante);
+            return ResponseEntity.status(status).body("Participante removido com sucesso da comunidade.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
         }
     }
 }

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ParticipantesController.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/controllers/ParticipantesController.java
@@ -1,4 +1,5 @@
 package pe.rec.comunidades.manguebits.controllers;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pe.rec.comunidades.manguebits.dto.LoginDTO;
@@ -56,5 +57,40 @@ public class ParticipantesController {
             return ResponseEntity.status(500).body(new ErrorResponse("Erro no servidor"));
         }
     }
+
+    // 🔹 Relacionamento com comunidades
+    @GetMapping("/{idParticipante}/comunidades")
+    public ResponseEntity<?> listarComunidades(@PathVariable Long idParticipante) {
+        try {
+            return ResponseEntity.ok(participantesService.listarComunidadesDoParticipante(idParticipante));
+        } catch (Exception e) {
+            return ResponseEntity.status(404).body(new ErrorResponse(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/{idParticipante}/comunidades/{idComunidade}")
+    public ResponseEntity<?> adicionarComunidade(
+            @PathVariable Long idParticipante,
+            @PathVariable Long idComunidade) {
+        try {
+            HttpStatus status = participantesService.adicionarComunidade(idParticipante, idComunidade);
+            return ResponseEntity.status(status).body("Comunidade adicionada com sucesso ao participante.");
+        } catch (Exception e) {
+            return ResponseEntity.status(400).body(new ErrorResponse(e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{idParticipante}/comunidades/{idComunidade}")
+    public ResponseEntity<?> removerComunidade(
+            @PathVariable Long idParticipante,
+            @PathVariable Long idComunidade) {
+        try {
+            HttpStatus status = participantesService.removerComunidade(idParticipante, idComunidade);
+            return ResponseEntity.status(status).body("Comunidade removida com sucesso do participante.");
+        } catch (Exception e) {
+            return ResponseEntity.status(400).body(new ErrorResponse(e.getMessage()));
+        }
+    }
+
 }
 

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/interfaces/services/IParticipantesService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/interfaces/services/IParticipantesService.java
@@ -1,11 +1,20 @@
 package pe.rec.comunidades.manguebits.interfaces.services;
 
+import org.springframework.http.HttpStatus;
+import pe.rec.comunidades.manguebits.model.Comunidades;
 import pe.rec.comunidades.manguebits.model.Participantes;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface IParticipantesService {
     Participantes createParticipante(Participantes participante);
 
     Optional<Participantes> login(String email, String senha);
+
+    List<Comunidades> listarComunidadesDoParticipante(Long idParticipante);
+
+    HttpStatus adicionarComunidade(Long idParticipante, Long idComunidade);
+
+    HttpStatus removerComunidade(Long idParticipante, Long idComunidade);
 }

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
@@ -34,6 +34,23 @@ public class Comunidades implements Serializable {
     private LocalDateTime updatedAt;
     @OneToMany(mappedBy = "comunidade", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Posts> posts = new ArrayList<Posts>();
+    @ManyToMany(mappedBy = "comunidades", fetch = FetchType.LAZY)
+    private List<Participantes> participantes = new ArrayList<>();
+
+
+    public List<Participantes> getParticipantes() {
+        return participantes;
+    }
+
+    public void addParticipante(Participantes participante) {
+        this.participantes.add(participante);
+        participante.getComunidades().add(this);
+    }
+
+    public void removeParticipante(Participantes participante) {
+        this.participantes.remove(participante);
+        participante.getComunidades().remove(this);
+    }
 
 
     public Comunidades() {}

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Participantes.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Participantes.java
@@ -3,6 +3,8 @@ package pe.rec.comunidades.manguebits.model;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "participantes")
@@ -30,6 +32,31 @@ public class Participantes {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "participantes_comunidades",
+            joinColumns = @JoinColumn(name = "id_participante"),
+            inverseJoinColumns = @JoinColumn(name = "id_comunidade")
+    )
+
+    private List<Comunidades> comunidades = new ArrayList<>();
+
+    public List<Comunidades> getComunidades() {
+        return comunidades;
+    }
+
+    public void addComunidade(Comunidades comunidade) {
+        this.comunidades.add(comunidade);
+        comunidade.getParticipantes().add(this);
+    }
+
+    public void removeComunidade(Comunidades comunidade) {
+        this.comunidades.remove(comunidade);
+        comunidade.getParticipantes().remove(this);
+    }
+
+
 
     public Long getId() {
         return id;

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ComunidadesService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ComunidadesService.java
@@ -4,11 +4,14 @@ package pe.rec.comunidades.manguebits.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import pe.rec.comunidades.manguebits.dto.comunidadesDTO.ComunidadesCreateDTO;
 import pe.rec.comunidades.manguebits.dto.comunidadesDTO.ComunidadesUpdateDTO;
 import pe.rec.comunidades.manguebits.dto.postsDTO.PostsCreateDTO;
 import pe.rec.comunidades.manguebits.model.Comunidades;
+import pe.rec.comunidades.manguebits.model.Participantes;
 import pe.rec.comunidades.manguebits.repositories.ComunidadesRepository;
+import pe.rec.comunidades.manguebits.repositories.ParticipantesRepository;
 import pe.rec.comunidades.manguebits.utils.communitiesUtils.ComunidadesUtils;
 
 import java.util.List;
@@ -18,11 +21,15 @@ import java.util.Optional;
 @Service
 public class ComunidadesService {
     private final ComunidadesRepository repository;
+    private final ParticipantesRepository participantesRepository;
     private final PostsService postsService;
 
     @Autowired
-    public ComunidadesService(ComunidadesRepository repository, PostsService postsService) {
-        this.repository = repository;
+    public ComunidadesService(ComunidadesRepository comunidadesRepository,
+                              ParticipantesRepository participantesRepository,
+                              PostsService postsService) {
+        this.repository = comunidadesRepository;
+        this.participantesRepository = participantesRepository;
         this.postsService = postsService;
     }
 
@@ -73,6 +80,29 @@ public class ComunidadesService {
     public void delete(Long id) {
         Comunidades community = this.findById(id);
         this.repository.delete(community);
+    }
+
+    @Transactional
+    public HttpStatus adicionarParticipante(Long idComunidade, Long idParticipante) {
+        Comunidades comunidade = findById(idComunidade);
+        Participantes participante = participantesRepository.findById(idParticipante)
+                .orElseThrow(() -> new NoSuchElementException("Participante não encontrado."));
+
+        if (!comunidade.getParticipantes().contains(participante)) {
+            comunidade.addParticipante(participante);
+            repository.save(comunidade);
+        }
+        return HttpStatus.OK;
+    }
+    @Transactional
+    public HttpStatus removerParticipante(Long idComunidade, Long idParticipante) {
+        Comunidades comunidade = findById(idComunidade);
+        Participantes participante = participantesRepository.findById(idParticipante)
+                .orElseThrow(() -> new NoSuchElementException("Participante não encontrado."));
+
+        comunidade.removeParticipante(participante);
+        repository.save(comunidade);
+        return HttpStatus.NO_CONTENT;
     }
 }
 

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ParticipantesService.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/services/ParticipantesService.java
@@ -1,19 +1,29 @@
 package pe.rec.comunidades.manguebits.services;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pe.rec.comunidades.manguebits.model.Comunidades;
+import pe.rec.comunidades.manguebits.repositories.ComunidadesRepository;
 import pe.rec.comunidades.manguebits.repositories.ParticipantesRepository;
 import pe.rec.comunidades.manguebits.interfaces.services.IParticipantesService;
 import pe.rec.comunidades.manguebits.model.Participantes;
 
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
 public class ParticipantesService implements IParticipantesService {
 
     private final ParticipantesRepository participantesRepository;
+    private final ComunidadesRepository comunidadesRepository;
 
-    public ParticipantesService(ParticipantesRepository participantesRepository) {
+
+    public ParticipantesService(ParticipantesRepository participantesRepository,
+                                ComunidadesRepository comunidadesRepository) {
         this.participantesRepository = participantesRepository;
+        this.comunidadesRepository = comunidadesRepository;
     }
 
     @Override
@@ -37,4 +47,43 @@ public class ParticipantesService implements IParticipantesService {
     public Optional<Participantes> login(String email, String senha) {
         return participantesRepository.findByEmailAndSenha(email, senha);
     }
+
+    /** Retorna todas as comunidades em que o participante está */
+    public List<Comunidades> listarComunidadesDoParticipante(Long idParticipante) {
+        Participantes participante = participantesRepository.findById(idParticipante)
+                .orElseThrow(() -> new NoSuchElementException("Participante não encontrado."));
+        return participante.getComunidades();
+    }
+
+    @Transactional
+    public HttpStatus adicionarComunidade(Long idParticipante, Long idComunidade) {
+        Participantes participante = participantesRepository.findById(idParticipante)
+                .orElseThrow(() -> new NoSuchElementException("Participante não encontrado."));
+
+        Comunidades comunidade = comunidadesRepository.findById(idComunidade)
+                .orElseThrow(() -> new NoSuchElementException("Comunidade não encontrada."));
+
+        if (!participante.getComunidades().contains(comunidade)) {
+            participante.addComunidade(comunidade);
+            participantesRepository.save(participante);
+        }
+
+        return HttpStatus.OK;
+    }
+
+    /** Remove comunidade do participante */
+    @Transactional
+    public HttpStatus removerComunidade(Long idParticipante, Long idComunidade) {
+        Participantes participante = participantesRepository.findById(idParticipante)
+                .orElseThrow(() -> new NoSuchElementException("Participante não encontrado."));
+
+        Comunidades comunidade = comunidadesRepository.findById(idComunidade)
+                .orElseThrow(() -> new NoSuchElementException("Comunidade não encontrada."));
+
+        participante.removeComunidade(comunidade);
+        participantesRepository.save(participante);
+
+        return HttpStatus.NO_CONTENT;
+    }
+
 }


### PR DESCRIPTION
Implementado relacionamento Many-to-Many entre Participantes e Comunidades.

Criados métodos no ParticipantesService para listar, adicionar e remover comunidades de um participante.

Adicionados novos endpoints REST no ParticipantesController para gerenciar esse vínculo.

Ajustada a camada de serviço e entidades para suportar o relacionamento.

Task:

https://github.com/users/wandersonlira/projects/4/views/1?pane=issue&itemId=136693503&issue=wandersonlira%7CManguebits%7C31