### PR TITLE
:bug: fix: Task #39 #33 - Ajuste no carregamento da classe Comunidades

### DIFF
--- a/manguebits/.gitignore
+++ b/manguebits/.gitignore
@@ -1,0 +1,59 @@
+# Build directories
+target/
+out/
+!**/src/main/**/target/
+!**/src/test/**/target/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+# IntelliJ IDEA
+.idea/
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+# Eclipse
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+/.mvn/
+.gradle/
+
+# NetBeans
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+# VS Code
+.vscode/
+
+# Mac OS
+.DS_Store
+
+# Windows
+Thumbs.db
+ehthumbs.db
+
+# Node.js (se houver)
+node_modules/
+yarn.lock
+package-lock.json
+
+### Environment variables
+.env
+
+# Log files
+*.log

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/config/CorsConfig.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/config/CorsConfig.java
@@ -9,7 +9,7 @@ public class CorsConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/manguebits/**")
+        registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")

--- a/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
+++ b/manguebits/src/main/java/pe/rec/comunidades/manguebits/model/Comunidades.java
@@ -1,5 +1,6 @@
 package pe.rec.comunidades.manguebits.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import pe.rec.comunidades.manguebits.enums.Categoria;
 
@@ -34,7 +35,7 @@ public class Comunidades implements Serializable {
     private LocalDateTime updatedAt;
     @OneToMany(mappedBy = "comunidade", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Posts> posts = new ArrayList<Posts>();
-    @ManyToMany(mappedBy = "comunidades", fetch = FetchType.LAZY)
+    @JsonIgnore @ManyToMany(mappedBy = "comunidades", fetch = FetchType.LAZY)
     private List<Participantes> participantes = new ArrayList<>();
 
 


### PR DESCRIPTION
## Descrição resumida
Ao tentar carregar o participante com suas respectivas comunidades acontecia loop de chamada de objetos. Foi inserido @JsonIgnore no lado de comunidade para ajustar o comportamento.
> _**Obs:** Houve excluir o `.gitignore` no commit anterior portanto foi necessário recria-lo._ 
